### PR TITLE
Refines MT5 Sizing Precision and Updates Project Details

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ backtest = strategy.backtest(
     backtest_name=strategy_id,
     start_date=from_date,
     end_date=to_date,
-    export_backtest_csv=True
+    export_backtest_csv=True,
     export_backtest_parquet=False,
     account_currency='USD'
 )

--- a/example_bbands_breakout.py
+++ b/example_bbands_breakout.py
@@ -171,6 +171,7 @@ backtest = strategy.backtest(
     backtest_name=strategy_id,
     start_date=from_date,
     end_date=to_date,
+    export_backtest_csv=True,
     export_backtest_parquet=False,
     account_currency='USD'
 )

--- a/pyeventbt/sizing_engine/sizing_engines/mt5_risk_pct_sizing.py
+++ b/pyeventbt/sizing_engine/sizing_engines/mt5_risk_pct_sizing.py
@@ -135,12 +135,12 @@ class MT5RiskPctSizing(ISizingEngine):
             entry_price: Decimal = signal_event.order_price
         
         # Get the symbol properties needed to accurately calculate the position size
-        equity                  = account_info.equity
-        volume_step             = symbol_info.volume_step               # the minimum volume change step when placing an order
-        tick_size               = symbol_info.trade_tick_size           # the smallest possible price change
-        contract_size           = symbol_info.trade_contract_size       # the size of 1 lot
-        account_currency        = account_info.currency                 # the account currency
-        symbol_profit_currency  = symbol_info.currency_profit           # the profit currency of the symbol
+        equity                  = Decimal(str(account_info.equity))
+        volume_step             = Decimal(str(symbol_info.volume_step))               # the minimum volume change step when placing an order
+        tick_size               = Decimal(str(symbol_info.trade_tick_size))           # the smallest possible price change
+        contract_size           = Decimal(str(symbol_info.trade_contract_size))       # the size of 1 lot
+        account_currency        = account_info.currency                               # the account currency
+        symbol_profit_currency  = symbol_info.currency_profit                         # the profit currency of the symbol
         
         tick_value_profit_ccy   = contract_size * tick_size    # Amount gained or losed for a full contract and a tick price move
         tick_value_account_ccy  = Utils.convert_currency_amount_to_another_currency(tick_value_profit_ccy, symbol_profit_currency, account_currency, modules.DATA_PROVIDER)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Event-driven backtesting and live trading framework for Python an
 authors = ["Marti Castany, Alain Porto"]
 readme = "README.md"
 license = "Apache-2.0"
-homepage = "https://github.com/marticastany/pyeventbt"
+homepage = "https://pyeventbt.com"
 repository = "https://github.com/marticastany/pyeventbt"
 keywords = [
     "mt5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyeventbt"
-version = "0.0.4"
+version = "0.0.5"
 description = "Event-driven backtesting and live trading framework for Python and MetaTrader 5"
 authors = ["Marti Castany, Alain Porto"]
 readme = "README.md"


### PR DESCRIPTION
Ensures accurate MT5 position sizing calculations by explicitly converting critical account and symbol properties to `Decimal`. This change prevents potential floating-point precision issues in financial computations.

Additionally, this update:
*   Increments the project version to `0.0.5`.
*   Directs the project homepage to the dedicated website: `pyeventbt.com`.
*   Corrects a minor syntax error in the README example.
*   Adds an example of how to enable CSV export for backtests in the `bbands_breakout` example.