### PR TITLE
Support custom reporting and enhanced event tracking in Hooks

### DIFF
--- a/pyeventbt/hooks/hook_service.py
+++ b/pyeventbt/hooks/hook_service.py
@@ -9,12 +9,12 @@ Licensed under the Apache License, Version 2.0
 """
 
 from enum import Enum
-from typing import Dict, Callable, List
+from typing import Dict, Callable, List, Optional
 
 from pyeventbt.strategy.core.modules import Modules
+from pyeventbt.events.events import EventBase
 
 class Hooks(str, Enum):
-    
     ON_START = 'ON_START'
     """Hook that executes on the start of backtest or live run
     """
@@ -24,6 +24,9 @@ class Hooks(str, Enum):
     ON_ORDER_EVENT = 'ON_ORDER_EVENT'
     """Hook that is executed when a ORDER_EVENT has being captured (RISK_ENGINE approves SuggestedOrder)
     """
+    ON_FILL_EVENT = 'ON_FILL_EVENT'
+    """Hook that is executed when a FILL_EVENT has being captured (When a trade is executed)
+    """
     ON_END = 'ON_END'
     """Hook that is executed when the end of the backtest/live trading has being reach
     """
@@ -32,9 +35,6 @@ class Hooks(str, Enum):
         return hash(self.name)
 
 class HookService:
-    """Service to handle hooks and their callbacks
-    """
-    
     def __init__(self) -> None:
         self.__hooks_callbacks: Dict[Hooks, List[Callable[[Modules], None]]] = {}
         self.__hooks_enabled = True
@@ -46,13 +46,19 @@ class HookService:
         self.__hooks_enabled = False
     
     def add_hook(self, hook: Hooks, callback: Callable[[Modules], None]):
-        
         self.__hooks_callbacks.setdefault(hook, []).append(callback)
         
-    def call_callbacks(self, hook: Hooks, modules: Modules):
-        
+    def call_callbacks(self, hook: Hooks, modules: Modules, event: Optional[EventBase] = None):
         if not self.__hooks_enabled:
             return
         
         for callback in self.__hooks_callbacks.get(hook, []):
-            callback(modules)
+            if event is not None:
+                try:
+                    # Try calling with both modules and event
+                    callback(modules, event)
+                except TypeError:
+                    # Fallback for backward compatibility with legacy callbacks
+                    callback(modules)
+            else:
+                callback(modules)

--- a/pyeventbt/trading_director/trading_director.py
+++ b/pyeventbt/trading_director/trading_director.py
@@ -101,16 +101,17 @@ class TradingDirector():
         self.SIGNAL_GENERATOR.generate_signal(event)
 
     def _handle_signal_event(self, event: SignalEvent) -> None:
-        self.HOOK_SERVICE.call_callbacks(Hooks.ON_SIGNAL_EVENT, self.MODULES)
+        self.HOOK_SERVICE.call_callbacks(Hooks.ON_SIGNAL_EVENT, self.MODULES, event)
         self.PORTFOLIO_HANDLER.process_signal_event(event)
 
     def _handle_order_event(self, event: OrderEvent) -> None:
         self.EXECUTION_ENGINE._process_order_event(event)
-        self.HOOK_SERVICE.call_callbacks(Hooks.ON_ORDER_EVENT, self.MODULES)
+        self.HOOK_SERVICE.call_callbacks(Hooks.ON_ORDER_EVENT, self.MODULES, event)
 
     def _handle_fill_event(self, event: FillEvent) -> None:
+        self.HOOK_SERVICE.call_callbacks(Hooks.ON_FILL_EVENT, self.MODULES, event)
         self.PORTFOLIO_HANDLER.process_fill_event(event)
-    
+
     def _handle_none_event(self, event):
         logger.warning(f"Received a NONE event: {event}")
 


### PR DESCRIPTION
Hey @marticastany, This introduces changes to the hook system to allow custom reporting and enhanced event tracking. Hooks now receive the specific event object (`Signal`, `Order`, or `Fill`) that triggered them, in addition to the Modules object.

Changes:

- Hook Service: Added `ON_FILL_EVENT` hook and updated `call_callbacks` to support passing an **event** object. It includes a fallback mechanism to ensure existing callbacks that only accept the Modules argument continue to work without modification.
- Trading Director: Updated to pass the relevant event objects (`SignalEvent`, `OrderEvent`, `FillEvent`) to the hook service when triggers occur.

Why: These changes are required to support custom reporting where access to the specific event details (like execution price, quantity, or signal strength) is necessary within the hook callbacks.