### PR TITLE
Fixes symbol duplication in data connectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to PyEventBT will be documented in this file.
 
+## [0.0.9] - 2026-04-16
+
+### Bug Fixes
+
+- Deduplicate `tradeable_symbol_list` in both CSV and MT5 live data connectors to prevent a symbol's data generator from advancing multiple times per cycle. When a symbol appeared more than once in the list, its generator was called N times per `update_bars()` cycle, causing that symbol to process bars at Nx speed and desynchronize from other symbols. A warning is now logged when duplicates are removed.
+
 ## [0.0.8] - 2026-04-14
 
 ### Bug Fixes

--- a/pyeventbt/data_provider/connectors/csv_data_connector.py
+++ b/pyeventbt/data_provider/connectors/csv_data_connector.py
@@ -76,8 +76,11 @@ class CSVDataProvider(IDataProvider):
         self.account_currency = configs.account_currency
 
         # auxiliary crosses
-        self.auxiliary_symbol_list = self._create_auxiliary_symbol_list(configs.tradeable_symbol_list, self.account_currency)
-        self.tradeable_symbols = configs.tradeable_symbol_list
+        self.tradeable_symbols = list(dict.fromkeys(configs.tradeable_symbol_list))
+        if len(self.tradeable_symbols) != len(configs.tradeable_symbol_list):
+            duplicates = list(dict.fromkeys(s for s in configs.tradeable_symbol_list if configs.tradeable_symbol_list.count(s) > 1))
+            logger.warning(f"You had duplicated symbols in your symbol list: {duplicates}. Duplicates have been automatically removed — no action needed.")
+        self.auxiliary_symbol_list = self._create_auxiliary_symbol_list(self.tradeable_symbols, self.account_currency)
         self.symbol_list = self.tradeable_symbols + self.auxiliary_symbol_list
 
         # will hold per‐symbol, per‐tf DataFrames

--- a/pyeventbt/data_provider/connectors/mt5_live_data_connector.py
+++ b/pyeventbt/data_provider/connectors/mt5_live_data_connector.py
@@ -45,7 +45,10 @@ class Mt5LiveDataProvider(IDataProvider):
         downloading the historical data for the symbols in the symbol list.
         """
         #self.event_queue = event_queue
-        self.symbol_list = configs.tradeable_symbol_list
+        self.symbol_list = list(dict.fromkeys(configs.tradeable_symbol_list))
+        if len(self.symbol_list) != len(configs.tradeable_symbol_list):
+            duplicates = list(dict.fromkeys(s for s in configs.tradeable_symbol_list if configs.tradeable_symbol_list.count(s) > 1))
+            logger.warning(f"You had duplicated symbols in your symbol list: {duplicates}. Duplicates have been automatically removed — no action needed.")
         self.timeframes_list = configs.timeframes_list
 
         # We need to store the datetime of the last bar seen for each symbol so we can generate the events with update_bars()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyeventbt"
-version = "0.0.8"
+version = "0.0.9"
 description = "Event-driven backtesting and live trading framework for Python and MetaTrader 5"
 authors = ["Marti Castany, Alain Porto"]
 readme = "README.md"


### PR DESCRIPTION
Addresses a bug where duplicate symbols in the `tradeable_symbol_list` caused incorrect bar processing. Previously, a symbol appearing multiple times would have its data generator called repeatedly per cycle, leading to accelerated processing and desynchronization from other symbols.

The CSV and MT5 live data connectors now automatically deduplicate the `tradeable_symbol_list` during initialization. A warning is logged when duplicates are removed, informing users of the correction without requiring any action.