### PR TITLE
Add data provider factor parameter to Strategy.backtest

### DIFF
--- a/pyeventbt/strategy/strategy.py
+++ b/pyeventbt/strategy/strategy.py
@@ -309,7 +309,8 @@ class Strategy:
             run_scheduled_taks: bool = False,
             export_backtest_csv: bool = False,
             export_backtest_parquet: bool = True,
-            backtest_results_dir: str|None = None
+            backtest_results_dir: str|None = None,
+            data_provider_factory=None,
         ):
         if symbols_to_trade is None:
             symbols_to_trade = ['EURUSD']
@@ -342,7 +343,11 @@ class Strategy:
             backtest_end_timestamp = end_date
         )
         
-        DATA_PROVIDER = DataProvider(self.EVENTS_QUEUE, bt_data_provider_config, trading_context)
+        DATA_PROVIDER = (
+            data_provider_factory(self.EVENTS_QUEUE)
+            if data_provider_factory is not None
+            else DataProvider(self.EVENTS_QUEUE, bt_data_provider_config, trading_context)
+        )
         
         # mgn = int(self.__create_mg_for_strategy_id(strategy_id))
         


### PR DESCRIPTION
# PyEventBT: `data_provider_factory` Injection Patch

## Summary

A minimal one-parameter addition to `Strategy.backtest()` that allows callers to inject
a pre-built `DataProvider`-compatible service object instead of having `backtest()` always
construct a `CSVDataProvider` internally.

---

## Motivation

`Strategy.backtest()` hardcodes the data provider construction:

```python
DATA_PROVIDER = DataProvider(self.EVENTS_QUEUE, bt_data_provider_config, trading_context)
```

The `DataProvider` service always wraps a `CSVDataProvider`, which reads historical data from
CSV files on disk. There is no way for callers to supply an alternative data provider
(e.g. an in-memory provider, a database-backed provider, or a custom feed) without
duplicating ~50 lines of object-assembly code.

---

## The Change

**File:** `pyeventbt/strategy/strategy.py`

### 1. Add `data_provider_factory=None` parameter to `backtest()`

```python
# Before
def backtest(
    self,
    strategy_id: str = "123456",
    ...
    backtest_results_dir: str|None = None
):

# After
def backtest(
    self,
    strategy_id: str = "123456",
    ...
    backtest_results_dir: str|None = None,
    data_provider_factory=None,          # NEW
):
```

### 2. Use the factory when provided

```python
# Before
DATA_PROVIDER = DataProvider(self.EVENTS_QUEUE, bt_data_provider_config, trading_context)

# After
DATA_PROVIDER = (
    data_provider_factory(self.EVENTS_QUEUE)
    if data_provider_factory is not None
    else DataProvider(self.EVENTS_QUEUE, bt_data_provider_config, trading_context)
)
```

The factory receives `events_queue` (a freshly created `Queue`) as its sole argument and must
return an object that satisfies the `DataProvider` service interface:

| Attribute / Method         | Type / Signature                                |
|----------------------------|-------------------------------------------------|
| `trading_context`          | `TypeContext`                                   |
| `events_queue`             | `Queue`                                         |
| `DATA_PROVIDER`            | inner data connector (e.g. `CSVDataProvider`)   |
| `continue_backtest`        | `bool` (mutable, read by `TradingDirector`)     |
| `close_positions_end_of_data` | `bool` (mutable, read by `TradingDirector`) |
| `get_latest_bar(symbol, tf)` | `BarEvent`                                    |
| `get_latest_bars(symbol, tf, N)` | `pl.DataFrame`                          |
| `get_latest_tick(symbol)`  | `dict`                                          |
| `get_latest_bid(symbol)`   | `Decimal`                                       |
| `get_latest_ask(symbol)`   | `Decimal`                                       |
| `get_latest_datetime(symbol, tf)` | `datetime`                             |
| `update_bars()`            | puts `BarEvent`s in `events_queue`, updates flags |

---

## Why a Factory Instead of an Instance?

`strategy.backtest()` creates a fresh `Queue` object at the top of the method:

```python
self.EVENTS_QUEUE = Queue()
```

All downstream objects (`DataProvider`, `ExecutionEngine`, `TradingDirector`, …) are wired to
this specific queue. A pre-built data-provider service would hold a reference to the **old**
queue and its events would never be seen by `TradingDirector`.

By accepting a **factory callable** instead of a ready-made instance, the caller can defer
construction until after the queue is created:

```python
def factory(events_queue: Queue) -> MyDataProviderService:
    return MyDataProviderService(events_queue, my_data)

results = strategy.backtest(..., data_provider_factory=factory)
```

---

## Backward Compatibility

The parameter defaults to `None`, so every existing call to `strategy.backtest()` is
**100% unaffected**. The CSV-based flow is used whenever `data_provider_factory` is not
supplied.

---

## Usage Example: In-Memory Data Provider

A common use case is loading data from a Polars DataFrame (e.g. fetched from a database or
constructed at runtime) instead of CSV files. The pattern is:

1. **Subclass `CSVDataProvider`** and override `_open_convert_csv_files()` to populate the
   internal data structures directly instead of reading from disk.
2. **Wrap it in a `DataProvider`-compatible service** that is built inside the factory
   (after `events_queue` is available).
3. **Pass the factory** to `strategy.backtest()`.

```python
from queue import Queue
from pyeventbt.data_provider.csv_data_provider import CSVDataProvider
from pyeventbt.data_provider.data_provider import DataProvider

class InMemoryCSVDataProvider(CSVDataProvider):
    """CSVDataProvider subclass that uses a pre-loaded Polars DataFrame."""

    def __init__(self, events_queue, config, trading_context, data: "pl.DataFrame", symbol: str, timeframe: str):
        self._injected_data = data
        self._injected_symbol = symbol
        self._injected_timeframe = timeframe
        # Parent __init__ calls _open_convert_csv_files() last — our override runs instead
        super().__init__(events_queue, config, trading_context)

    def _open_convert_csv_files(self):
        """Populate internal data structures from the injected DataFrame."""
        symbol = self._injected_symbol
        tf = self._injected_timeframe
        df = self._injected_data

        self.complete_symbol_data_timeframes[symbol] = {tf: df}
        self.continue_backtest = True
        # Initialise generator for bar-by-bar iteration
        self._generators[symbol] = {tf: self._bar_generator(symbol, tf)}


class InMemoryDataProviderService:
    """Thin DataProvider-compatible wrapper around InMemoryCSVDataProvider."""

    def __init__(self, events_queue: Queue, config, trading_context, data, symbol, timeframe):
        self.DATA_PROVIDER = InMemoryCSVDataProvider(
            events_queue, config, trading_context, data, symbol, timeframe
        )
        self.trading_context = trading_context
        self.events_queue = events_queue

    # Delegate the DataProvider service interface to the inner provider
    @property
    def continue_backtest(self):
        return self.DATA_PROVIDER.continue_backtest

    @continue_backtest.setter
    def continue_backtest(self, value):
        self.DATA_PROVIDER.continue_backtest = value

    @property
    def close_positions_end_of_data(self):
        return self.DATA_PROVIDER.close_positions_end_of_data

    def update_bars(self):
        self.DATA_PROVIDER.update_bars()

    def get_latest_bar(self, symbol, tf):
        return self.DATA_PROVIDER.get_latest_bar(symbol, tf)

    def get_latest_bars(self, symbol, tf, N=1):
        return self.DATA_PROVIDER.get_latest_bars(symbol, tf, N)

    def get_latest_datetime(self, symbol, tf):
        return self.DATA_PROVIDER.get_latest_datetime(symbol, tf)

    def get_latest_bid(self, symbol):
        return self.DATA_PROVIDER.get_latest_bid(symbol)

    def get_latest_ask(self, symbol):
        return self.DATA_PROVIDER.get_latest_ask(symbol)

    def get_latest_tick(self, symbol):
        return self.DATA_PROVIDER.get_latest_tick(symbol)
```

Wire it up using a factory:

```python
import polars as pl

# Your data — columns: datetime, open, high, low, close, tickvol, volume, spread
data: pl.DataFrame = ...

def make_factory(config, trading_context, data, symbol, timeframe):
    def factory(events_queue: Queue) -> InMemoryDataProviderService:
        return InMemoryDataProviderService(
            events_queue, config, trading_context, data, symbol, timeframe
        )
    return factory

from pyeventbt.strategy.strategy import Strategy

class MyStrategy(Strategy):
    def calculate_signals(self, event):
        # your signal logic here
        pass

strategy = MyStrategy(symbols=["EURUSD"], timeframes=["H1"])
results = strategy.backtest(
    strategy_id="my_strategy",
    data_provider_factory=make_factory(config, trading_context, data, "EURUSD", "H1"),
)
```

---

This change is intentionally minimal and fully backward-compatible.
