### PR TITLE
Fixes MT5 connector `AttributeError` on `None` result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to PyEventBT will be documented in this file.
 
+## [0.0.11] - 2026-05-27
+
+Fixes a crash in the MT5 live execution engine connector when `mt5.order_send()` returns `None`. The connector correctly detected the failure but then attempted to read `.retcode` and `.request.symbol` on the `None` result while formatting the warning log, raising an `AttributeError` that propagated up through `run_live` and stopped the strategy.
+
+### Bug Fixes
+
+- Fixed `AttributeError` in `update_position_sl_tp` and `cancel_pending_order` when `mt5.order_send()` returns `None` (e.g. on transient trade-server disconnects). Both branches now log `mt5.last_error()` instead of dereferencing the missing result.
+- Added an early `return None` in `place_pending_order` and `cancel_pending_order` when the order send returns `None`, so the subsequent `result._asdict()` call no longer crashes after a failed send.
+
+**Full Changelog**: [v0.0.10...v0.0.11](https://github.com/marticastany/pyeventbt/compare/v0.0.10...v0.0.11)
+
 ## [0.0.10] - 2026-05-22
 
 This release expands the list of supported symbols, enhances the hook system with a new `ON_FILL_EVENT` hook and richer callback signatures, and addresses a correctness issue in the backtesting simulator that prevented some stop loss modifications on open positions.

--- a/pyeventbt/execution_engine/connectors/mt5_live_execution_engine_connector.py
+++ b/pyeventbt/execution_engine/connectors/mt5_live_execution_engine_connector.py
@@ -411,10 +411,11 @@ class Mt5LiveExecutionEngineConnector(IExecutionEngine):
         else:
             if result is None:
                 logger.warning(f"Pending Order for {symbol} failed. Result is None. Last error: {mt5.last_error()}")
+                return None
             else:
                 logger.warning(f"Pending Order for {symbol} failed with retcode: {result.retcode}. Last error: {mt5.last_error()}")
 
-        
+
         # Convert the result to a dictionary and add the request as a dictionary too. Then convert it back to an OrderSendResult object
         dict_result = result._asdict()
         dict_result['request'] = result.request._asdict()

--- a/pyeventbt/execution_engine/connectors/mt5_live_execution_engine_connector.py
+++ b/pyeventbt/execution_engine/connectors/mt5_live_execution_engine_connector.py
@@ -554,8 +554,12 @@ class Mt5LiveExecutionEngineConnector(IExecutionEngine):
         if self._check_succesful_order_execution(result):
             logger.info(f"Order {result.order} successfully cancelled")
         else:
-            logger.warning(f"Cancel Pending Order for {result.request.symbol} failed with retcode: {result.retcode}. Last error: {mt5.last_error()}")
-        
+            if result is None:
+                logger.warning(f"Cancel Pending Order for ticket {order_ticket} failed. Result is None. Last error: {mt5.last_error()}")
+                return None
+            else:
+                logger.warning(f"Cancel Pending Order for {result.request.symbol} failed with retcode: {result.retcode}. Last error: {mt5.last_error()}")
+
         # Convert the result to a dictionary and add the request as a dictionary too. Then convert it back to an OrderSendResult object
         dict_result = result._asdict()
         dict_result['request'] = result.request._asdict()

--- a/pyeventbt/execution_engine/connectors/mt5_live_execution_engine_connector.py
+++ b/pyeventbt/execution_engine/connectors/mt5_live_execution_engine_connector.py
@@ -618,7 +618,10 @@ class Mt5LiveExecutionEngineConnector(IExecutionEngine):
         if self._check_succesful_order_execution(result):
             logger.info(f"Position {position_ticket} SL/TP updated to {new_sl:.5f}/{new_tp:.5f}")
         else:
-            logger.warning(f"Update Position SL/TP for {position_ticket} failed with retcode: {result.retcode}. Last error: {mt5.last_error()}")
+            if result is None:
+                logger.warning(f"Update Position SL/TP for {position_ticket} failed. Result is None. Last error: {mt5.last_error()}")
+            else:
+                logger.warning(f"Update Position SL/TP for {position_ticket} failed with retcode: {result.retcode}. Last error: {mt5.last_error()}")
     
     def _get_account_currency(self) -> str:
         """Get account currency"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyeventbt"
-version = "0.0.10"
+version = "0.0.11"
 description = "Event-driven backtesting and live trading framework for Python and MetaTrader 5"
 authors = ["Marti Castany, Alain Porto"]
 readme = "README.md"


### PR DESCRIPTION
Addresses a critical `AttributeError` in the MT5 live execution engine connector that occurred when `mt5.order_send()` or `mt5.position_modify()` returned `None` due to a failed operation (e.g., transient trade-server disconnects). Previously, the connector would attempt to read `.retcode` or `.request.symbol` from the `None` result while formatting warning logs, leading to a crash that could stop the strategy.

This change enhances the connector's robustness by:
- Implementing checks for `None` results from MT5 API calls in `place_pending_order`, `cancel_pending_order`, and `update_position_sl_tp`.
- Logging `mt5.last_error()` directly when an operation returns `None`, preventing `AttributeError`.
- Adding early returns in `place_pending_order` and `cancel_pending_order` when a `None` result is encountered, preventing subsequent crashes when attempting to convert the result to a dictionary.

Updates the project version to `0.0.11`.