### PR TITLE
Fixes MT5 SL/TP update with non-float values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to PyEventBT will be documented in this file.
 
+## [0.0.12] - 2026-05-29
+
+Fixes a failed stop-loss/take-profit modification in the MT5 live execution engine connector when a caller passes a non-`float` numeric (e.g. a `Decimal`) for `new_sl`/`new_tp`. `mt5.order_send()` only accepts native Python floats for the `sl`/`tp` request fields, so a `Decimal` made the send return `None` with last error `(-2, 'Invalid "sl" argument')` and the modification was silently dropped. This complements the 0.0.11 fix, which handled the `None` result gracefully but did not address why the send was failing. The backtest simulator accepts `Decimal`, so the issue only surfaced in live trading.
+
+### Bug Fixes
+
+- Cast `new_sl`/`new_tp` to `float` when building the `TRADE_ACTION_SLTP` request in `update_position_sl_tp`, so callers passing `Decimal` (or other numerics) no longer trigger `(-2, 'Invalid "sl" argument')` from `mt5.order_send()`. The order-placement paths already cast their `sl`/`tp`; this brings the SL/TP-modification path in line.
+
+**Full Changelog**: [v0.0.11...v0.0.12](https://github.com/marticastany/pyeventbt/compare/v0.0.11...v0.0.12)
+
 ## [0.0.11] - 2026-05-27
 
 Fixes a crash in the MT5 live execution engine connector when `mt5.order_send()` returns `None`. The connector correctly detected the failure but then attempted to read `.retcode` and `.request.symbol` on the `None` result while formatting the warning log, raising an `AttributeError` that propagated up through `run_live` and stopped the strategy.

--- a/pyeventbt/execution_engine/connectors/mt5_live_execution_engine_connector.py
+++ b/pyeventbt/execution_engine/connectors/mt5_live_execution_engine_connector.py
@@ -607,8 +607,12 @@ class Mt5LiveExecutionEngineConnector(IExecutionEngine):
         update_request = {
             'action': mt5.TRADE_ACTION_SLTP,
             'position': position_ticket,
-            'sl': new_sl if new_sl != 0.0 else current_sl,
-            'tp': new_tp if new_tp != 0.0 else current_tp,
+            # mt5.order_send only accepts native floats for sl/tp; a Decimal (or
+            # other numeric) passed by a caller makes order_send return None with
+            # (-2, 'Invalid "sl" argument'). current_sl/current_tp come from the
+            # MT5 position object and are already floats.
+            'sl': float(new_sl) if new_sl != 0.0 else current_sl,
+            'tp': float(new_tp) if new_tp != 0.0 else current_tp,
         }
 
         # Send the order request and get the result as a OrderSendResult object

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyeventbt"
-version = "0.0.11"
+version = "0.0.12"
 description = "Event-driven backtesting and live trading framework for Python and MetaTrader 5"
 authors = ["Marti Castany, Alain Porto"]
 readme = "README.md"


### PR DESCRIPTION
Ensures stop-loss and take-profit modifications in the MT5 live execution engine connector succeed when callers pass non-float numeric types (e.g., `Decimal`).

Previously, `mt5.order_send()` would silently fail with an "Invalid 'sl' argument" error if `new_sl` or `new_tp` were not native Python `float` types. This led to dropped SL/TP updates in live trading, as the modification request was silently rejected by the MT5 terminal.

*   Casts `new_sl` and `new_tp` to `float` before building the `TRADE_ACTION_SLTP` request.
*   Aligns this modification path with existing order-placement paths, which already cast `sl`/`tp` to `float`, preventing future discrepancies.