### PR TITLE
Fixes MT5 live data bar duplication race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to PyEventBT will be documented in this file.
 
+## [0.0.13] - 2026-06-04
+
+Fixes a redundant MT5 query in the live data provider that, in a rare timing window, could skip a bar and duplicate the next one. In `Mt5LiveDataProvider.update_bars`, a new bar was detected and recorded using one `get_latest_bar` call, but the bar actually delivered to the event queue came from a *second* `get_latest_bar` call. If a timeframe boundary fell between the two calls (a sub-millisecond window), the second call returned a different, newer bar than the one recorded in `last_bar_tf_datetime` — causing the gated bar to be skipped and the newer bar to be re-emitted on the following cycle. The fix reuses the already-fetched bar, which also removes a redundant IPC round-trip per symbol/timeframe on every update cycle. Backtesting is unaffected.
+
+### Bug Fixes
+
+- Reuse the already-fetched bar in `Mt5LiveDataProvider.update_bars` instead of calling `get_latest_bar` a second time to build the event. This eliminates a race where a timeframe boundary between the two calls could skip the detected bar and duplicate the next one, and halves the MT5 IPC calls made per symbol/timeframe on each update.
+
+**Full Changelog**: [v0.0.12...v0.0.13](https://github.com/marticastany/pyeventbt/compare/v0.0.12...v0.0.13)
+
 ## [0.0.12] - 2026-05-29
 
 Fixes a failed stop-loss/take-profit modification in the MT5 live execution engine connector when a caller passes a non-`float` numeric (e.g. a `Decimal`) for `new_sl`/`new_tp`. `mt5.order_send()` only accepts native Python floats for the `sl`/`tp` request fields, so a `Decimal` made the send return `None` with last error `(-2, 'Invalid "sl" argument')` and the modification was silently dropped. This complements the 0.0.11 fix, which handled the `None` result gracefully but did not address why the send was failing. The backtest simulator accepts `Decimal`, so the issue only surfaced in live trading.

--- a/pyeventbt/data_provider/connectors/mt5_live_data_connector.py
+++ b/pyeventbt/data_provider/connectors/mt5_live_data_connector.py
@@ -415,11 +415,16 @@ class Mt5LiveDataProvider(IDataProvider):
                     # Update the latest seen datetime
                     self.last_bar_tf_datetime[symbol][timeframe] = latest_bar.datetime
 
-                    # Add the Bar Event to the event list
+                    # Add the Bar Event to the event list.
+                    # Reuse the bar we already fetched and gated on above instead of
+                    # querying MT5 a second time: a re-fetch can straddle a timeframe
+                    # boundary and return a different (newer) bar than the one recorded
+                    # in last_bar_tf_datetime, which would skip the gated bar and
+                    # duplicate the next one. It also avoids a redundant IPC round-trip.
                     # if symbol_is_futures:
                     #     events_container_list.append(self.get_latest_bar(symbol_contract, timeframe))
                     # else:
-                    events_container_list.append(self.get_latest_bar(symbol, timeframe))
+                    events_container_list.append(latest_bar)
         
         return events_container_list
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyeventbt"
-version = "0.0.12"
+version = "0.0.13"
 description = "Event-driven backtesting and live trading framework for Python and MetaTrader 5"
 authors = ["Marti Castany, Alain Porto"]
 readme = "README.md"


### PR DESCRIPTION
Addresses a race condition in the MT5 live data provider that could lead to bar events being skipped or duplicated in live trading.

Previously, detecting a new bar and creating its event involved two separate `get_latest_bar` calls. If a timeframe boundary fell between these two calls, the second call could return a different, newer bar. This would cause the initially detected bar to be skipped and the newer bar to be re-emitted on the following cycle.

The fix reuses the already-fetched bar object for event creation, eliminating this timing window. This change also optimizes performance by halving the number of IPC calls to MT5 per symbol and timeframe on each update cycle.