### PR TITLE
Add symbols_info_override to Strategy.backtest() for per-run symbol/margin config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to PyEventBT will be documented in this file.
 
+## [Unreleased]
+
+Adds a `symbols_info_override` parameter to `Strategy.backtest()` so callers can override any `SymbolInfo` field for a single backtest run without editing the packaged `default_symbols_info.yaml`. The simulator derives required margin solely from each symbol's `margin_initial` (e.g. `0.0333` → 30:1), so this is the supported way to change a symbol's effective leverage for a backtest — previously only achievable by editing the vendored YAML inside the installed package. A `"*"` key applies an override to every symbol; explicit per-symbol keys take precedence, and values are coerced to each field's existing type so `Decimal` fields (such as `margin_initial`) stay `Decimal` and margin arithmetic remains exact.
+
+### Features
+
+- Add `symbols_info_override` to `Strategy.backtest()`: a `dict[str, dict]` mapping a symbol name (or `"*"` for all symbols) to a dict of `SymbolInfo` field → value overrides, applied after the simulator loads its defaults and before the run starts. Enables per-run margin/leverage configuration (and any other symbol field) without modifying the packaged `default_symbols_info.yaml`.
+
+**Full Changelog**: [v0.0.13...HEAD](https://github.com/marticastany/pyeventbt/compare/v0.0.13...HEAD)
+
 ## [0.0.13] - 2026-06-04
 
 Fixes a redundant MT5 query in the live data provider that, in a rare timing window, could skip a bar and duplicate the next one. In `Mt5LiveDataProvider.update_bars`, a new bar was detected and recorded using one `get_latest_bar` call, but the bar actually delivered to the event queue came from a *second* `get_latest_bar` call. If a timeframe boundary fell between the two calls (a sub-millisecond window), the second call returned a different, newer bar than the one recorded in `last_bar_tf_datetime` — causing the gated bar to be skipped and the newer bar to be re-emitted on the following cycle. The fix reuses the already-fetched bar, which also removes a redundant IPC round-trip per symbol/timeframe on every update cycle. Backtesting is unaffected.

--- a/pyeventbt/strategy/strategy.py
+++ b/pyeventbt/strategy/strategy.py
@@ -49,6 +49,7 @@ from pyeventbt.risk_engine.services.risk_engine_service import RiskEngineService
 from queue import Queue
 from typing import Callable
 from datetime import datetime, timedelta
+from decimal import Decimal
 from functools import partial
 from pyeventbt.utils.utils import LoggerColorFormatter
 from pyeventbt.utils.utils import TerminalColors, colorize
@@ -294,6 +295,52 @@ class Strategy:
     def activate_schedules(self):
         self.__run_schedules = True
 
+    @staticmethod
+    def _apply_symbols_info_override(symbols_info_override: dict[str, dict]) -> None:
+        """Apply per-run SymbolInfo field overrides onto the loaded simulator data.
+
+        Mutates ``SharedData.symbol_info`` in place. The ``"*"`` key (if present)
+        is applied to every symbol first, so explicit per-symbol entries win.
+        Values are coerced to each field's existing type, which keeps Decimal
+        fields (e.g. ``margin_initial``) Decimal so margin arithmetic stays exact
+        (mixing Decimal and float raises TypeError in the margin formula).
+
+        Args:
+            symbols_info_override (dict[str, dict]): Mapping of symbol name (or
+                ``"*"``) to a dict of ``SymbolInfo`` field -> value overrides.
+
+        Raises:
+            KeyError: if a named symbol is not in the loaded symbol set.
+            AttributeError: if an overridden field does not exist on SymbolInfo.
+        """
+        symbols = SharedData.symbol_info
+
+        # Apply the wildcard first so explicit per-symbol overrides take precedence.
+        ordered = sorted(symbols_info_override.items(), key=lambda kv: kv[0] != "*")
+
+        for symbol_name, field_overrides in ordered:
+            if symbol_name == "*":
+                targets = list(symbols.values())
+            elif symbol_name in symbols:
+                targets = [symbols[symbol_name]]
+            else:
+                raise KeyError(
+                    f"symbols_info_override: unknown symbol '{symbol_name}' "
+                    f"(not in the loaded symbol set)."
+                )
+
+            for target in targets:
+                for field, value in field_overrides.items():
+                    if not hasattr(target, field):
+                        raise AttributeError(
+                            f"symbols_info_override: SymbolInfo has no field '{field}'."
+                        )
+                    current = getattr(target, field)
+                    # str() avoids float->Decimal precision noise (Decimal(0.0005)).
+                    if isinstance(current, Decimal) and not isinstance(value, Decimal):
+                        value = Decimal(str(value))
+                    setattr(target, field, value)
+
     ############################# CREATION OF BACKTEST OBJECTS AND LAUNCHING THE SIMULATOR #############################
     def backtest(
             self,
@@ -309,14 +356,42 @@ class Strategy:
             run_scheduled_taks: bool = False,
             export_backtest_csv: bool = False,
             export_backtest_parquet: bool = True,
-            backtest_results_dir: str|None = None
+            backtest_results_dir: str|None = None,
+            symbols_info_override: dict[str, dict] | None = None
         ):
+        """Run an event-driven backtest of the configured strategy.
+
+        ``symbols_info_override`` overrides any ``SymbolInfo`` field per run
+        *without* editing the packaged ``default_symbols_info.yaml``. The
+        simulator derives required margin solely from each symbol's
+        ``margin_initial`` (e.g. ``0.0333`` -> 30:1), so this is the supported
+        way to change a symbol's effective leverage for a backtest. Use the
+        ``"*"`` key to apply an override to every symbol; explicit per-symbol
+        keys take precedence.
+
+        >>> strategy = Strategy()
+        >>> strategy.backtest(
+        >>>     symbols_to_trade=["GBPUSD"],
+        >>>     symbols_info_override={"*": {"margin_initial": 0.0005}},  # 2000:1
+        >>> )
+
+        Args:
+            symbols_info_override (dict[str, dict], optional): Mapping of symbol
+                name (or ``"*"`` for all symbols) to a dict of ``SymbolInfo``
+                field -> value overrides, applied after the simulator loads its
+                defaults. Defaults to None (packaged values unchanged).
+        """
         if symbols_to_trade is None:
             symbols_to_trade = ['EURUSD']
 
         # Reset SharedData to YAML defaults so sequential backtests (e.g. optimization loops)
         # start with clean simulator state (symbol_info, account_info, etc.)
         SharedData()
+
+        # Apply any per-run symbol-info overrides on top of the freshly loaded
+        # defaults (e.g. margin_initial to set a symbol's effective leverage).
+        if symbols_info_override:
+            self._apply_symbols_info_override(symbols_info_override)
 
         # the queue is instantited here to avoid problems when performing a backtest inside a backtest.
         self.EVENTS_QUEUE = Queue()


### PR DESCRIPTION
hey @marticastany, based on your recommendation https://github.com/marticastany/pyeventbt/pull/15#issuecomment-4521083089

## Summary

Adds an optional `symbols_info_override` parameter to `Strategy.backtest()` that lets callers override any `SymbolInfo` field for a single backtest run without editing the packaged `default_symbols_info.yaml`.

The simulator derives required margin solely from each symbol's `margin_initial` (e.g. `0.0333` -> 30:1) in `_compute_required_margin_for_order_in_account_currency`. Today the only way to change a symbol's effective leverage is to edit the vendored YAML inside the installed package, which is fragile (wiped on reinstall), not version-controllable, and cannot vary per run. This exposes that knob at the API level — the design-sanctioned way to control leverage, since margin comes from `margin_initial`, not from `account_leverage`.

## What changed

- New `backtest(..., symbols_info_override: dict[str, dict] | None = None)` parameter.
- Applied right after `SharedData()` reloads the defaults (so it survives the per-run reset) and before the simulation starts.
- A `"*"` key applies to every symbol; explicit per-symbol keys take precedence.
- Values are coerced to each field's existing type, so `Decimal` fields like `margin_initial` stay `Decimal` and the margin formula (`volume * contract_size * margin_initial`) stays exact instead of raising `TypeError` on `Decimal * float`.
- Unknown symbol -> `KeyError`; unknown field -> `AttributeError` (typo protection).
- Added a docstring + example to `backtest()` and a CHANGELOG `[Unreleased]` entry.

## Usage

```python
strategy.backtest(
    symbols_to_trade=["GBPUSD"],
    symbols_info_override={
        "*": {"margin_initial": 0.001},        # 1000:1 on every symbol
        "GBPUSD": {"margin_initial": 0.0005},  # 2000:1 just for GBPUSD
    },
)
```

## Why not wire `account_leverage` into the margin formula

Dividing required margin by `account_leverage` would double-discount margin (margin is already defined by `margin_initial`) and under-charge it. This PR deliberately keeps the existing margin semantics intact and instead makes the sanctioned `margin_initial` knob configurable per run.

## Verification

- `strategy.py` compiles.
- Functional test against this branch's source: `{"*": {"margin_initial": 0.001}, "GBPUSD": {"margin_initial": 0.0005}}` set EURUSD -> 1000:1 and GBPUSD -> 2000:1 (per-symbol overriding the wildcard); values stayed `Decimal`; the margin formula computed without error; error paths raised as expected.